### PR TITLE
C-API example: fix runtime issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 Cargo.lock
 /venv
 **/*.o
+**/*.map
 **/.gdb_history

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "c-api/libopencm3"]
+	path = c-api/libopencm3
+	url = https://github.com/libopencm3/libopencm3

--- a/c-api/Makefile
+++ b/c-api/Makefile
@@ -7,26 +7,21 @@ build:
 	cp target/$(TARGET)/debug/libsalty_c_api.a libsalty-debug.a
 
 deep-clean: clean
-	rm -rf example/libopencm3
 
 clean:
 	cargo clean
 	make -C example clean
 
-prepare-example:
-	-git clone https://github.com/libopencm3/libopencm3 example/libopencm3
-	# FP_FLAGS="-mfloat-abi=soft" $(MAKE) -C example/libopencm3
-	$(MAKE) -C example/libopencm3
-	# for some reason, libopencm3 overwrites our nice `link.x`
-	git checkout example/link.x
+libopencm3/lib/libopencm3_stm32f4.a:
+	$(MAKE) -C libopencm3
 
-build-example:
+build-example: libopencm3/lib/libopencm3_stm32f4.a
 	$(MAKE) -C example
 
 SEMIHOSTING = -semihosting-config enable=on,target=native
 SPEC = -cpu cortex-m33 -machine musca-b1 -nographic
 run-example:
-	# Get out via Ctrl-A X
+	# Get out via Ctrl-A X in case QEMU does not return
 	qemu-system-arm $(SPEC) $(SEMIHOSTING) -kernel example/example.elf
 
 run-example-gdb:
@@ -36,3 +31,5 @@ run-example-gdb:
 gdb-example:
 	arm-none-eabi-gdb -q -x ../qemu-tests/qemu.gdb example/example.elf
 	qemu-system-arm $(SPEC) $(SEMIHOSTING) -kernel example/example.elf -gdb tcp::1234 -S
+
+.PHONY: build clean deep-clean build-example run-example run-example-gdb gdb-example

--- a/c-api/example/Makefile
+++ b/c-api/example/Makefile
@@ -4,20 +4,28 @@ BUILD_DIR = bin
 CFILES = $(PROJECT).c
 
 # TODO - you will need to edit these two lines!
-DEVICE=stm32f407vgt6
-OOCD_FILE = board/stm32f4discovery.cfg
+### DEVICE=stm32f407vgt6
+### OOCD_FILE = board/stm32f4discovery.cfg
 
-VPATH += $(SHARED_DIR)
-INCLUDES += $(patsubst %,-I%, . $(SHARED_DIR))
-OPENCM3_DIR=libopencm3
+# use 'manual' board setup to avoid linker script generation
+# this is a hybrid setup for running an STM32F4 targeted binary on the ARM
+# musca B1 evaluation board, which is the only working cortex M4 compatible
+# platform found in QEMU
+LDSCRIPT     = musca-b1.ld
+OPENCM3_LIB  = opencm3_stm32f4
+OPENCM3_DEFS = -DSTM32F4 -DSTM32F4CCM -DSTM32F407VGT6
+ARCH_FLAGS   = -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16
+
+# SEMIHOSTING
+LDFLAGS += -specs=rdimon.specs
+LDLIBS  += -lrdimon
+
+OPENCM3_DIR=../libopencm3
 
 INCLUDES += -I..
 LDLIBS += ../libsalty.a
 LDLIBS += ../libsalty-asm.a
-LDSCRIPT = link.x
-LDFLAGS	+= --specs=rdimon.specs
-LDLIBS+= -lc -lrdimon
 
-include $(OPENCM3_DIR)/mk/genlink-config.mk
+###include $(OPENCM3_DIR)/mk/genlink-config.mk
 include rules.mk
-include $(OPENCM3_DIR)/mk/genlink-rules.mk
+###include $(OPENCM3_DIR)/mk/genlink-rules.mk

--- a/c-api/example/example.c
+++ b/c-api/example/example.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <stdio.h>
+#include <unistd.h>
 #include "salty.h"
 
 extern void  initialise_monitor_handles(void);
@@ -31,11 +32,11 @@ int main(void) {
 
     salty_public_key(&seed, &public_key);
     salty_sign(&seed, data, 6, &signature);
-    salty_verify(&public_key, data, sizeof(data), &signature);
+    salty_Error err = salty_verify(&public_key, data, sizeof(data), &signature);
 
     /* assert(1); */
 
-    printf("signature generated\n");
+    printf("signature generated, verify returns: %d\n", err);
 
     /* let keypair = salty::Keypair::from(&seed); */
 
@@ -55,6 +56,9 @@ int main(void) {
     /*     0x32, 0xf9, 0xa6, 0x44, 0x2a, 0x17, 0xbc, 0x09, */
     /* ]; */
 
-    while (1) { continue; }
-    return 0;
+	/*
+	 * If running under QEMU, _exit() will also stop QEMU returning err.
+	 * If running on hardware, libopencm3 should handle correctly.
+	 */
+	_exit(err);
 }

--- a/c-api/example/musca-b1.ld
+++ b/c-api/example/musca-b1.ld
@@ -2,9 +2,8 @@ EXTERN(vector_table)
 ENTRY(reset_handler)
 MEMORY
 {
- ram (rwx) : ORIGIN = 0x30000000, LENGTH = 128K
- rom (rx) : ORIGIN = 0x10000000, LENGTH = 1024K
- ccm (rwx) : ORIGIN = 0x10000000, LENGTH = 64K
+ ram (rwx) : ORIGIN = 0x30000000, LENGTH =  128K
+ rom (rx) : ORIGIN =  0x10000000, LENGTH = 1024K
 }
 SECTIONS
 {
@@ -58,10 +57,6 @@ SECTIONS
   . = ALIGN(4);
   _ebss = .;
  } >ram
- .ccm : {
-  *(.ccmram*)
-  . = ALIGN(4);
- } >ccm
  /DISCARD/ : { *(.eh_frame) }
  . = ALIGN(4);
  end = .;


### PR DESCRIPTION
- Linker script is no longer generated, but libopencm3 uses the fixed configuration style.

- The `ccm` RAM region leftover from the STM32F4 configuration has been removed. Now, `end` is correctly calculated by the linker and libc actually works, no longer overwriting global variables.

- rules.mk refreshed from libopencm3-template and linker map generation enabled.

- Example checks verify return value, prints it out and also returns the result from `main()`. Actually, `_exit()` is used to make QEMU return, too.

This can now be run like so:

```
$ make run-example
# Get out via Ctrl-A X in case QEMU does not return
qemu-system-arm -cpu cortex-m33 -machine musca-b1 -nographic \
  -semihosting-config enable=on,target=native -kernel example/example.elf
signature generated, verify returns: 3
make: *** [Makefile:25: run-example] Error 3
```

(The original finding from #4 has intentionally not been fixed, to show the testing possibility like above. Otherwise, this fixes #4.)
