### PR TITLE
Remove version field from wycheproof* dev-deps to make Cargo publishable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ zeroize = { version = "1.2.0", default-features = false }
 [dev-dependencies]
 hex = { version = "0.4.2", default-features = false }
 hex-literal = "0.2.1"
-wycheproof = { version = "0.1", path = "wycheproof" }
-wycheproof-gen = { version = "0.1", path = "wycheproof/wycheproof-gen" }
+wycheproof = { path = "wycheproof" }
+wycheproof-gen = { path = "wycheproof/wycheproof-gen" }
 
 [features]
 slow-motion = []


### PR DESCRIPTION
@enrikb FYI the solution was so simple, one only has to actually read https://github.com/rust-lang/cargo/pull/7333 🙈.