### PR TITLE
Implement Generic traits from signature/ed25519 crates and bump to Rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ cosey = { version = "0.3.0", optional = true }
 subtle = { version = "2.4.0", default-features = false }
 zeroize = { version = "1.2.0", default-features = false }
 ed25519 = { version = "1.3.0", default-features = false }
-signature = { version = "1.4.0", default-features = false }
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ keywords = ["no-std", "NaCl", "Ed25519", "cryptography", "signatures"]
 cosey = { version = "0.3.0", optional = true }
 subtle = { version = "2.4.0", default-features = false }
 zeroize = { version = "1.2.0", default-features = false }
+ed25519 = { version = "1.3.0", default-features = false }
+signature = { version = "1.4.0", default-features = false }
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "salty"
 version = "0.2.0-alpha.2"
 authors = ["Nicolas Stalder <n@stalder.io>"]
-edition = "2018"
+edition = "2021"
 description = "Small, sweet, swift Ed25519 signatures for microcontrollers"
 homepage = "https://salty.rs"
 repository = "https://github.com/nickray/salty"

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -69,7 +69,6 @@ static K: [u64; 80] = [
 
 fn hash_blocks(digest: &mut [u8; 64], msg: &[u8]) -> usize {
     #![allow(non_snake_case)]
-    use core::convert::TryInto;
 
     // convert digest (u8-array) into hash parts (u64-words array)
     let mut H: [Wrapping<u64>; 8] = Default::default(); //[Wrapping(0); 8];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,6 @@ pub use scalar::Scalar;
 pub mod signature;
 // TODO: rename these (and handle the API-breaking consequences)
 // It's confusing now that we have both Edwards and Montgomery points.
-pub use signature::{SecretKey, PublicKey, Keypair, Signature};
+pub use crate::signature::{SecretKey, PublicKey, Keypair, Signature};
 #[cfg(feature = "cose")]
 pub use signature::CosePublicKey;

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -178,7 +178,6 @@ impl Keypair {
 
 impl signature::Signer<ed25519::Signature> for Keypair {
     fn try_sign(&self, msg: &[u8]) -> core::result::Result<ed25519::Signature, signature::Error> {
-        use core::convert::TryInto;
         self.sign(msg).try_into()
     }
 }
@@ -319,7 +318,6 @@ impl TryFrom<&CosePublicKey> for PublicKey {
     type Error = crate::Error;
 
     fn try_from(cose: &CosePublicKey) -> Result<PublicKey> {
-        use core::convert::TryInto;
         let okp: &[u8; 32] = cose.x.as_ref().try_into().unwrap();
         Self::try_from(okp)
     }
@@ -401,7 +399,6 @@ impl TryFrom<Signature> for ed25519::Signature {
     type Error = signature::Error;
 
     fn try_from(sig: Signature) -> core::result::Result<ed25519::Signature, Self::Error> {
-        use core::convert::TryInto;
         (&sig.to_bytes()[..]).try_into()
     }
 }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,5 +1,3 @@
-use core::convert::TryFrom;
-
 #[cfg(feature = "cose")]
 pub use cosey::Ed25519PublicKey as CosePublicKey;
 
@@ -176,8 +174,8 @@ impl Keypair {
     }
 }
 
-impl signature::Signer<ed25519::Signature> for Keypair {
-    fn try_sign(&self, msg: &[u8]) -> core::result::Result<ed25519::Signature, signature::Error> {
+impl ed25519::signature::Signer<ed25519::Signature> for Keypair {
+    fn try_sign(&self, msg: &[u8]) -> core::result::Result<ed25519::Signature, ed25519::signature::Error> {
         self.sign(msg).try_into()
     }
 }
@@ -283,14 +281,14 @@ impl PublicKey {
 
 }
 
-impl signature::Verifier<ed25519::Signature> for PublicKey {
+impl ed25519::signature::Verifier<ed25519::Signature> for PublicKey {
     fn verify(&self, msg: &[u8], signature: &ed25519::Signature)
-        -> core::result::Result<(), signature::Error> {
+        -> core::result::Result<(), ed25519::signature::Error> {
         let bytes = signature.to_bytes();
         if self.verify(msg, &(&bytes).into()).is_ok() {
             Ok(())
         } else {
-            Err(signature::Error::new())
+            Err(ed25519::signature::Error::new())
         }
     }
 }
@@ -396,7 +394,7 @@ impl From<ed25519::Signature> for Signature {
 }
 
 impl TryFrom<Signature> for ed25519::Signature {
-    type Error = signature::Error;
+    type Error = ed25519::signature::Error;
 
     fn try_from(sig: Signature) -> core::result::Result<ed25519::Signature, Self::Error> {
         (&sig.to_bytes()[..]).try_into()


### PR DESCRIPTION
This PR adds From/TryFrom conversions from/to the ed25519 [Signature](https://docs.rs/ed25519/1.3.0/ed25519/struct.Signature.html) type and impls to the [Verifier](https://docs.rs/signature/1.4.0/signature/trait.Verifier.html)/[Signer](https://docs.rs/signature/1.4.0/signature/trait.Signer.html) trait from the signature crate.

An implementation of the [signature::Signature](https://docs.rs/signature/1.4.0/signature/trait.Signature.html) was not made deliberately, as that prescribes that the signature is stored as a raw byte format in memory, although IMO that is debatable.

This fixes #23.