### PR TITLE
Prepare release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.1] - 2023-07-04
+## [0.3.0] - 2023-10-21
 - accept any 32 byte array as X25519 public key per RFC 7748
+  - breaking as TryFrom turned to From
 - bump edition to 2021 throughout
 - cargo clippy + fmt
 - bump dependency versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ homepage = "https://github.com/ycrypto/salty"
 license = "Apache-2.0 OR MIT"
 readme = "README.md"
 repository = "https://github.com/ycrypto/salty"
-version = "0.2.1"
+version = "0.3.0"
 
 [package]
 name = "salty"


### PR DESCRIPTION
We decided that accepting all public keys was a breaking change (TryFrom turned into From for PublicKey).
Changes in CHANGELOG.