### PR TITLE
Move support for cosey v0.4 behind cosey-v0.4 feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- add `cosey-v0.4` feature to enable support for `cosey` v0.4
+
 ## [0.3.0] - 2023-10-21
 - accept any 32 byte array as X25519 public key per RFC 7748
   - breaking as TryFrom turned to From

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ wycheproof-macros = { path = "wycheproof/macros" }
 wycheproof-parser = { path = "wycheproof/parser" }
 wycheproof-types = { path = "wycheproof/types" }
 
-cosey = { version = "0.4" }
+cosey = { version = "0.3" }
 ed25519 = { version = "2.2", default-features = false }
 hex = "0.4"
 hex-literal = "0.4"
@@ -55,6 +55,7 @@ subtle.workspace = true
 zeroize.workspace = true
 
 cosey = { workspace = true, optional = true}
+cosey04 = { package = "cosey", version = "0.4", optional = true }
 ed25519 = { workspace = true, optional = true}
 
 [dev-dependencies]
@@ -66,7 +67,10 @@ wycheproof-types.workspace = true
 [features]
 default = ["rustcrypto"]
 slow-motion = []
+# this feature is kept for compatibility and can be removed in a breaking release
 cose = ["cosey"]
+"cosey-v0.3" = ["cosey"]
+"cosey-v0.4" = ["dep:cosey04"]
 rustcrypto = ["ed25519"]
 
 [profile.release.package.salty-c-api]

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ fix: fmt
 check:
 	# cargo check --all
 	cargo check -p salty
+	cargo check -p salty --all-features
 	cargo check -p salty-c-api --target thumbv7em-none-eabi
 	cargo check -p qemu-tests
 	cargo check -p wycheproof-macros

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -312,20 +312,39 @@ impl PublicKey {
     }
 }
 
-#[cfg(feature = "cose")]
-impl From<PublicKey> for CosePublicKey {
-    fn from(key: PublicKey) -> CosePublicKey {
-        CosePublicKey {
-            x: cosey::Bytes::from(key.as_bytes()),
+#[cfg(feature = "cosey-v0.3")]
+impl From<PublicKey> for cosey::Ed25519PublicKey {
+    fn from(key: PublicKey) -> Self {
+        Self {
+            x: cosey::Bytes::from_slice(key.as_bytes().as_ref()).unwrap(),
         }
     }
 }
 
-#[cfg(feature = "cose")]
-impl TryFrom<&CosePublicKey> for PublicKey {
+#[cfg(feature = "cosey-v0.3")]
+impl TryFrom<&cosey::Ed25519PublicKey> for PublicKey {
     type Error = crate::Error;
 
-    fn try_from(cose: &CosePublicKey) -> Result<PublicKey> {
+    fn try_from(cose: &cosey::Ed25519PublicKey) -> Result<PublicKey> {
+        let okp: &[u8; 32] = cose.x.as_ref().try_into().unwrap();
+        Self::try_from(okp)
+    }
+}
+
+#[cfg(feature = "cosey-v0.4")]
+impl From<PublicKey> for cosey04::Ed25519PublicKey {
+    fn from(key: PublicKey) -> Self {
+        Self {
+            x: cosey04::Bytes::from(key.as_bytes()),
+        }
+    }
+}
+
+#[cfg(feature = "cosey-v0.4")]
+impl TryFrom<&cosey04::Ed25519PublicKey> for PublicKey {
+    type Error = crate::Error;
+
+    fn try_from(cose: &cosey04::Ed25519PublicKey) -> Result<PublicKey> {
         let okp: &[u8; 32] = cose.x.as_ref().try_into().unwrap();
         Self::try_from(okp)
     }


### PR DESCRIPTION
This allows us to implement support for multiple cosey versions in a backwards-compatible manner.